### PR TITLE
Add AWSPricing::EC2 reserved instance pricing with option hashes

### DIFF
--- a/lib/aws-pricing/ec2.rb
+++ b/lib/aws-pricing/ec2.rb
@@ -2,14 +2,27 @@ module AWSPricing
   class EC2
     #Elastic Compute pricing data
     
-    EC2_BASE_URL = '/ec2/pricing/pricing-'
     
   
+    EC2_BASE_URL          = '/ec2/pricing/pricing-'
+    EC2_RESERVED_BASE_URL = '/ec2/pricing/'
+
     #Returns Hash of on-demand server instance pricing information
     def self.instances
       Base.get(EC2_BASE_URL + 'on-demand-instances')
     end
-    
+
+    #Returns Hash of reserved server instance pricing information
+    def self.reserved_instances(options = {})
+      os          = options[:os]          || 'linux'
+      utilization = options[:utilization] || 'heavy'
+
+      raise "AWSPricing: Invalid OS" unless /^linux|mswin+$/ =~ os
+      raise "AWSPricing: Invalid Utilization" unless /^light|medium|heavy$/ =~ utilization
+  
+      Base.get(EC2_RESERVED_BASE_URL + "ri-#{utilization}-#{os}")
+    end
+  
     #Returns Hash of current spot instance pricing information (5m)
     def self.spot_instances
       callback_response = Net::HTTP.get_response(URI.parse 'http://spot-price.s3.amazonaws.com/spot.js').body

--- a/spec/aws-pricing_spec.rb
+++ b/spec/aws-pricing_spec.rb
@@ -8,7 +8,45 @@ describe "AwsPricing" do
     it "returns a hash of instance pricing" do
       EC2.instances.class.should == Hash
     end
+
+    describe "reserved instances" do
+      it "returns a hash of reserved linux heavy utilization instance pricing by default" do
+        EC2.reserved_instances.class.should == Hash
+      end
+      it "returns a hash of reserved linux light utilization instance pricing" do
+        EC2.reserved_instances(:os => :linux, :utilization => :light).class.should == Hash
+      end
   
+      it "returns a hash of reserved linux medium utilization instance pricing" do
+        EC2.reserved_instances(:os => :linux, :utilization => :medium).class.should == Hash
+      end
+
+      it "returns a hash of reserved linux heavy utlization instance pricing" do
+        EC2.reserved_instances(:os => :linux, :utilization => :heavy).class.should == Hash
+      end
+
+
+      it "returns a hash of reserved mswin light utilization instance pricing" do
+        EC2.reserved_instances(:os => :mswin, :utilization => :light).class.should == Hash
+      end
+
+      it "returns a hash of reserved mswin medium utilization instance pricing" do
+        EC2.reserved_instances(:os => :mswin, :utilization => :medium).class.should == Hash
+      end
+
+      it "returns a hash of reserved mswin heavy utlization instance pricing" do
+        EC2.reserved_instances(:os => :mswin, :utilization => :heavy).class.should == Hash
+      end
+
+      it "raises an error if invalid os is provided" do
+        lambda { EC2.reserved_instances(:os => :macosx) }.should raise_error
+      end
+
+      it "raises an error if invalid utilization is provided" do
+        lambda { EC2.reserved_instances(:utilization => :none) }.should raise_error
+      end
+    end
+
     it "returns a hash of ebs pricing" do
       EC2.ebs.class.should == Hash
     end


### PR DESCRIPTION
Add reserve instance pricing. This is with option hashes. I also implemented a simpler class method version which you can see here: https://github.com/mrardon/aws-pricing/tree/feature-reserved-pricing

In an effort to prevent any other major changes I simply added my own in addition to your existing constant.

```
    EC2_BASE_URL          = '/ec2/pricing/pricing-'
    EC2_BASE_RESERVED_URL = '/ec2/pricing/'
```

Thanks
