### PR TITLE
"Properly" set default values

### DIFF
--- a/lib/aws-pricing/ec2.rb
+++ b/lib/aws-pricing/ec2.rb
@@ -14,13 +14,12 @@ module AWSPricing
 
     #Returns Hash of reserved server instance pricing information
     def self.reserved_instances(options = {})
-      os          = options[:os].to_s          || 'linux'
-      utilization = options[:utilization].to_s || 'heavy'
+      opts = { :os => 'linux', :utilization => 'heavy' }.merge(options)
 
-      raise "AWSPricing: Invalid OS" unless /^linux|mswin+$/ =~ os
-      raise "AWSPricing: Invalid Utilization" unless /^light|medium|heavy$/ =~ utilization
-  
-      Base.get(EC2_RESERVED_BASE_URL + "ri-#{utilization}-#{os}")
+      raise "AWSPricing: Invalid OS" unless /^linux|mswin+$/ =~ opts[:os].to_s
+      raise "AWSPricing: Invalid Utilization" unless /^light|medium|heavy$/ =~ opts[:utilization].to_s
+
+      Base.get(EC2_RESERVED_BASE_URL + "ri-#{opts[:utilization]}-#{opts[:os]}")
     end
   
     #Returns Hash of current spot instance pricing information (5m)


### PR DESCRIPTION
This should work in most Rubies from what I have found.

I original had the to_s in there but removed it because it prevents the default option from working on my Ruby 1.9.3p134.

I have found a better way, "I think"....

See http://stackoverflow.com/questions/1186400/correct-way-to-set-default-values-in-rails
